### PR TITLE
ci(security): use takumi guard for npm install

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,7 +5,9 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -18,7 +20,12 @@ jobs:
         with:
           node-version-file: .node-version
           cache: npm
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm i
+      - name: Restore .npmrc to avoid committing the registry auth token
+        run: git checkout -- .npmrc
 
       - run: aqua upc -prune
         env:

--- a/.github/workflows/create-pr-branch.yaml
+++ b/.github/workflows/create-pr-branch.yaml
@@ -14,9 +14,12 @@ on:
 jobs:
   create-pr-branch:
     uses: ./.github/workflows/wc-create-pr-branch.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     with:
       pr: ${{fromJSON(inputs.pr)}}
       is_comment: ${{inputs.is_comment}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,10 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
       - run: npm run build
       - uses: suzuki-shunsuke/release-js-action@ff106e3a3f5b34f174a23db3110031fbf463f15c # v0.2.1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -6,10 +6,13 @@ concurrency:
 jobs:
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
   status-check:
     runs-on: ubuntu-24.04
     if: failure()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -26,6 +27,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{github.token}}
           PR: ${{inputs.pr}}
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
       - run: npm run build
 

--- a/.github/workflows/wc-create-pr-branch.yaml
+++ b/.github/workflows/wc-create-pr-branch.yaml
@@ -13,6 +13,9 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   create-pr-branch:
     timeout-minutes: 30
@@ -20,6 +23,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -29,6 +33,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{github.token}}
           PR: ${{inputs.pr}}
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
       - run: npm run build
 

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -1,6 +1,10 @@
 ---
 name: Test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   test:
@@ -8,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -16,6 +21,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: npm
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
       - run: npm run build
 

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,5 +1,9 @@
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   path-filter:
     # Get changed files to filter jobs
@@ -41,6 +45,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     with:
       pr: ${{github.event.pull_request.number}}
 
@@ -48,3 +55,6 @@ jobs:
     uses: ./.github/workflows/wc-test.yaml
     permissions:
       issues: write
+      id-token: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@jsr:registry=https://npm.jsr.io
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://shisho.dev/docs/r/202604-takumi-guard-rate-limit/#getting-started-with-organization-usage) to authenticate npm installs against the private registry (`npm.flatt.tech`), mirroring csm-actions/securefix-action#668.

`.npmrc` points npm at `https://npm.flatt.tech/`, which requires authentication. This PR wires `flatt-security/setup-takumi-guard-npm` (OIDC-based) into every workflow that installs npm dependencies, so installs are authenticated through Takumi Guard.

## Changes

- **Track `.npmrc`** — the registry config (`@jsr` + `npm.flatt.tech`) is now committed so CI has it. It contains no token.
- **Add `setup-takumi-guard-npm@v1.1.1` before each `npm ci` / `npm i`** in `autofix.yaml`, `main.yaml`, `release.yaml`, `wc-test.yaml`, and `wc-create-pr-branch.yaml`, granting each job `id-token: write` for OIDC.
- **Thread the `TAKUMI_GUARD_BOT_ID` credential** through the reusable workflows and their callers:
  - `wc-test.yaml`, `wc-create-pr-branch.yaml`, `workflow_call_test.yaml` declare it as a required `workflow_call` input.
  - `pull_request.yaml`, `create-pr-branch.yaml`, and `workflow_call_test.yaml` pass it down and propagate `id-token: write`.
- **Restore `.npmrc` in `autofix`** — `setup-takumi-guard-npm` writes a short-lived registry auth token into `.npmrc`, and autofix-ci commits the whole working tree. `git checkout -- .npmrc` runs right after `npm i` so the token is never committed to the public PR branch.

## Prerequisite

A repository/organization variable-or-secret `TAKUMI_GUARD_BOT_ID` must be configured (the bot ID issued by Shisho Cloud).

## Validation

- `ghalint run` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
